### PR TITLE
Targets .NET 6.0 & upgrades packages

### DIFF
--- a/src/Domain.cs
+++ b/src/Domain.cs
@@ -29,7 +29,11 @@ namespace DotNetVersionInfo
             var pathTransformer = showRelativePaths
                 ? ToRelativePath(absoluteBaseDir)
                 : Identity;
-            var glob = new Glob(globPattern, _fileSystem) { ErrorLog = HandeGlobError };
+            var glob = new Glob(
+                globPattern,
+                new GlobOptions { ErrorLog = HandeGlobError },
+                _fileSystem
+            );
             return glob
                 .Expand()
                 .Cast<FileInfoBase>()

--- a/src/dotnet-versioninfo.csproj
+++ b/src/dotnet-versioninfo.csproj
@@ -4,8 +4,8 @@
     <ToolCommandName>versioninfo</ToolCommandName>
     <PackAsTool>True</PackAsTool>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <Version>1.0.2</Version>
+    <TargetFramework>net6.0</TargetFramework>
+    <Version>1.0.3</Version>
     <Description>Display version information of .NET Core assemblies</Description>
     <Authors>Jonathan Taylor</Authors>
     <PackageTags>.NET Core Global Tool</PackageTags>

--- a/src/dotnet-versioninfo.csproj
+++ b/src/dotnet-versioninfo.csproj
@@ -15,7 +15,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Glob.cs" Version="2.0.13" />
+    <PackageReference Include="Glob.cs" Version="5.1.*" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.2.3" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>

--- a/src/dotnet-versioninfo.csproj
+++ b/src/dotnet-versioninfo.csproj
@@ -16,8 +16,8 @@
 
   <ItemGroup>
     <PackageReference Include="Glob.cs" Version="5.1.*" />
-    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="2.2.3" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="4.0.*" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.*" />
   </ItemGroup>
 
 </Project>

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/tests.csproj
+++ b/tests/tests.csproj
@@ -7,12 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Glob.cs" Version="2.0.13" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
-    <PackageReference Include="System.IO.Abstractions" Version="2.1.0.228" />
-    <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="2.1.0.228" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="Glob.cs" Version="5.1.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.*" />
+    <PackageReference Include="xunit" Version="2.4.*" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.*" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 


### PR DESCRIPTION
I needed this tool in an environment which only has .NET 6.0 installed, so I made the changes in this PR.  You will see that I had to make a small change to Domain.cs to adapt to a change in Glob ctor (Glob.cs). Other than that, these changes are mostly concerned with target framework version and package upgrades.  This PR contains multiple commits, so you can select all or some.